### PR TITLE
specify files to scan by default

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,4 @@
   name: sort_makefile
   entry: sort_makefile
   language: python
-  pass_filenames: false
-  args: [filepath]
+  files: '[Mm]akefile'


### PR DESCRIPTION
fixup hook definition by specifying on which files it should be run